### PR TITLE
Bugfixed Visual Studio errors when compiled as C++ sources

### DIFF
--- a/lib/fse.c
+++ b/lib/fse.c
@@ -132,7 +132,7 @@ static U32 FSE_readLE32(const void* memPtr)
         return FSE_read32(memPtr);
     else
     {
-        const BYTE* p = memPtr;
+        const BYTE* p = (const BYTE*)memPtr;
         return (U32)((U32)p[0] + ((U32)p[1]<<8) + ((U32)p[2]<<16) + ((U32)p[3]<<24));
     }
 }
@@ -145,7 +145,7 @@ static void FSE_writeLE32(void* memPtr, U32 val32)
     }
     else
     {
-        BYTE* p = memPtr;
+        BYTE* p = (BYTE*)memPtr;
         p[0] = (BYTE)val32;
         p[1] = (BYTE)(val32>>8);
         p[2] = (BYTE)(val32>>16);
@@ -166,7 +166,7 @@ static U64 FSE_readLE64(const void* memPtr)
         return FSE_read64(memPtr);
     else
     {
-        const BYTE* p = memPtr;
+        const BYTE* p = (const BYTE*)memPtr;
         return (U64)((U64)p[0] + ((U64)p[1]<<8) + ((U64)p[2]<<16) + ((U64)p[3]<<24)
                      + ((U64)p[4]<<32) + ((U64)p[5]<<40) + ((U64)p[6]<<48) + ((U64)p[7]<<56));
     }
@@ -180,7 +180,7 @@ static void FSE_writeLE64(void* memPtr, U64 val64)
     }
     else
     {
-        BYTE* p = memPtr;
+        BYTE* p = (BYTE*)memPtr;
         p[0] = (BYTE)val64;
         p[1] = (BYTE)(val64>>8);
         p[2] = (BYTE)(val64>>16);
@@ -618,8 +618,8 @@ typedef struct
 
 int FSE_compareRankT(const void* r1, const void* r2)
 {
-    const rank_t* R1 = r1;
-    const rank_t* R2 = r2;
+    const rank_t* R1 = (const rank_t*)r1;
+    const rank_t* R2 = (const rank_t*)r2;
 
     return 2 * (R1->count < R2->count) - 1;
 }
@@ -1005,7 +1005,7 @@ size_t FSE_decompressRLE(void* dst, size_t originalSize,
 
 size_t FSE_buildDTable_rle (void* DTable, BYTE symbolValue)
 {
-    U32* const base32 = DTable;
+    U32* const base32 = (U32* const)DTable;
     FSE_decode_t* const cell = (FSE_decode_t*)(base32 + 1);
 
     /* Sanity check */
@@ -1023,7 +1023,7 @@ size_t FSE_buildDTable_rle (void* DTable, BYTE symbolValue)
 
 size_t FSE_buildDTable_raw (void* DTable, unsigned nbBits)
 {
-    U32* const base32 = DTable;
+    U32* const base32 = (U32* const)DTable;
     FSE_decode_t* dinfo = (FSE_decode_t*)(base32 + 1);
     const unsigned tableSize = 1 << nbBits;
     const unsigned tableMask = tableSize - 1;
@@ -1142,7 +1142,7 @@ unsigned FSE_reloadDStream(FSE_DStream_t* bitD)
 
 void FSE_initDState(FSE_DState_t* DStatePtr, FSE_DStream_t* bitD, const void* DTable)
 {
-    const U32* const base32 = DTable;
+    const U32* const base32 = (const U32* const)DTable;
     DStatePtr->state = FSE_readBits(bitD, base32[0]);
     FSE_reloadDStream(bitD);
     DStatePtr->table = base32 + 1;
@@ -1511,7 +1511,7 @@ void FSE_FUNCTION_NAME(FSE_freeDTable, FSE_FUNCTION_EXTENSION) (void* DTable)
 size_t FSE_FUNCTION_NAME(FSE_buildDTable, FSE_FUNCTION_EXTENSION)
 (void* DTable, const short* const normalizedCounter, unsigned maxSymbolValue, unsigned tableLog)
 {
-    U32* const base32 = DTable;
+    U32* const base32 = (U32* const)DTable;
     FSE_DECODE_TYPE* const tableDecode = (FSE_DECODE_TYPE*) (base32+1);
     const U32 tableSize = 1 << tableLog;
     const U32 tableMask = tableSize-1;


### PR DESCRIPTION
Hello Yann,

Here you have a few missing casts.
They're not required in C, but library will fail to compile in C++ mode otherwise
(reproduce it by typìng `cl.exe /Tp fse.c` and `cl.exe /Tp zstd.c`)

Great library.
Keep up the good work.
- r-lyeh


PS: I have kept your identation style when creating the type casts. Also, see errors bugfixed below:

```c++
fse.c(135) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
fse.c(148) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
fse.c(169) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
fse.c(183) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
fse.c(621) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const rank_t *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
fse.c(622) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const rank_t *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
fse.c(1008) : error C2440: 'initializing' : cannot convert from 'void *' to 'U32 *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
fse.c(1026) : error C2440: 'initializing' : cannot convert from 'void *' to 'U32 *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
fse.c(1145) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const U32 *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
fse.c(1514) : error C2440: 'initializing' : cannot convert from 'void *' to 'U32 *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast

zstd.c(205) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(206) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(213) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(230) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(279) : error C2440: 'initializing' : cannot convert from 'ZSTD_cctx_t' to 'refTables_t *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(440) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(461) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(954) : error C2664: 'size_t ZSTD_compressEntropy(BYTE *,size_t,const BYTE *,const BYTE *,const BYTE *,const BYTE *,const BYTE *,const U32 *,const BYTE *,const BYTE *,size_t,size_t)' : cannot convert argument 1 from 'void *' to 'BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1001) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1003) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1009) : error C2440: '=' : cannot convert from 'const void *' to 'const BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1013) : error C2440: '=' : cannot convert from 'const void *' to 'const BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1068) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1085) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1133) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1142) : error C2440: '=' : cannot convert from 'int' to 'blockType_t' Conversion to enumeration type requires an explicit cast (static_cast, C-style cast or function-style cast)
zstd.c(1233) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1261) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1263) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1303) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1397) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1399) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1561) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1563) : error C2440: 'initializing' : cannot convert from 'void *' to 'BYTE *const ' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1640) : error C2440: 'initializing' : cannot convert from 'void *' to 'dctx_t *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
zstd.c(1698) : error C2440: 'initializing' : cannot convert from 'const void *' to 'const BYTE *' Conversion from 'void*' to pointer to non-'void' requires an explicit cast
```