### PR TITLE
Add `unzstd` program for decompression.

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -99,16 +99,20 @@ install: zstd
 	@install -d -m 755 $(DESTDIR)$(BINDIR)/ $(DESTDIR)$(MANDIR)/
 	@install -m 755 zstd$(EXT) $(DESTDIR)$(BINDIR)/zstd$(EXT)
 	@ln -sf zstd$(EXT) $(DESTDIR)$(BINDIR)/zstdcat
+	@ln -sf zstd$(EXT) $(DESTDIR)$(BINDIR)/unzstd
 	@echo Installing man pages
 	@install -m 644 zstd.1 $(DESTDIR)$(MANDIR)/zstd.1
 	@install -m 644 zstdcat.1 $(DESTDIR)$(MANDIR)/zstdcat.1
+	@install -m 644 unzstd.1 $(DESTDIR)$(MANDIR)/unzstd.1
 	@echo zstd installation completed
 
 uninstall:
 	rm -f $(DESTDIR)$(BINDIR)/zstdcat
+	rm -f $(DESTDIR)$(BINDIR)/unzstd
 	[ -x $(DESTDIR)$(BINDIR)/zstd$(EXT) ] && rm -f $(DESTDIR)$(BINDIR)/zstd$(EXT)
 	[ -f $(DESTDIR)$(MANDIR)/zstd.1 ] && rm -f $(DESTDIR)$(MANDIR)/zstd.1
 	[ -f $(DESTDIR)$(MANDIR)/zstdcat.1 ] && rm -f $(DESTDIR)$(MANDIR)/zstdcat.1
+	[ -f $(DESTDIR)$(MANDIR)/unzstd.1 ] && rm -f $(DESTDIR)$(MANDIR)/unzstd.1
 	@echo zstd programs successfully uninstalled
 
 test: test-zstd test-fullbench test-fuzzer test-mem

--- a/programs/unzstd.1
+++ b/programs/unzstd.1
@@ -1,0 +1,31 @@
+\"
+\" unzstd.1: This is a manual page for 'unzstd' program. This file is part of
+\" the zstd <https://github.com/Cyan4973/zstd/> project.
+\"
+
+\" No hyphenation
+.hy 0
+.nr HY 0
+
+.TH unzstd "1" "2014-06-20" "unzstd" "User Commands"
+.SH NAME
+\fBunzstd\fR - Utility based on zstd
+
+.SH SYNOPSIS
+.TP 5
+\fBunzstd\fR [\fBOPTIONS\fR] [-|INPUT-FILE]
+
+.SH DESCRIPTION
+.PP
+\fBunzstd\fR is an utility based on \fBzstd\fR, a fast lossless compression algorithm.
+
+\fBunzstd\fR decompress input file, it is equivalent to \fBzstd -d\fR,
+
+Available options are the same as \fBzstd\fR ones (man zstd).
+
+
+.SH BUGS
+Report bugs at:- https://github.com/Cyan4973/zstd/
+
+.SH AUTHOR
+Yann Collet

--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -76,6 +76,7 @@
 #define WELCOME_MESSAGE "*** %s %i-bits %s, by %s (%s) ***\n", COMPRESSOR_NAME, (int)(sizeof(void*)*8), ZSTD_VERSION, AUTHOR, __DATE__
 #define ZSTD_EXTENSION ".zst"
 #define ZSTD_CAT "zstdcat"
+#define ZSTD_UNZSTD "unzstd"
 
 #define KB *(1 <<10)
 #define MB *(1 <<20)
@@ -170,8 +171,24 @@ int main(int argc, char** argv)
     char* dynNameSpace = NULL;
     char extension[] = ZSTD_EXTENSION;
 
+    
+    /* Pick out basename component. Don't rely on stdlib because of conflicting behaviour. */
+    for (i = strlen(programName); i > 0; i--)
+    {
+        if (programName[i] == '/')
+        {
+            i++;
+            break;
+        }
+    }
+    programName += i;
+
     /* zstdcat behavior */
     if (!strcmp(programName, ZSTD_CAT)) { decode=1; forceStdout=1; displayLevel=1; outFileName=stdoutmark; }
+
+    /* unzstd behavior */
+    if (!strcmp(programName, ZSTD_UNZSTD)) 
+        decode=1;
 
     // command switches
     for(i=1; i<argc; i++)


### PR DESCRIPTION
Add **unzstd** symlink to the distribution. Also ensure we use the basename(1) part of the program name, i.e. possible to call the program as ``./unzstd`` or ``/usr/local/bin/zstdcat`` and still get the expected behaviour.