### PR TITLE
Add __declspec(dllexport) via optional ZSTDLIB_API macro when building a DLL for Windows

### DIFF
--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -43,6 +43,24 @@ extern "C" {
 #include <stddef.h>   /* size_t */
 
 
+/* ***************************************************************
+*  Tuning parameters
+*****************************************************************/
+/*!
+*  ZSTD_DLL_EXPORT :
+*  Enable exporting of functions when building a DLL
+*/
+#if defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
+#  if _WIN32
+#    define ZSTDLIB_API __declspec(dllexport)
+#  else
+#    define ZSTDLIB_API extern
+#  endif
+#else
+#  define ZSTDLIB_API
+#endif
+
+
 /* *************************************
 *  Version
 ***************************************/
@@ -50,18 +68,18 @@ extern "C" {
 #define ZSTD_VERSION_MINOR    4    /* for new (non-breaking) interface capabilities */
 #define ZSTD_VERSION_RELEASE  3    /* for tweaks, bug-fixes, or development */
 #define ZSTD_VERSION_NUMBER  (ZSTD_VERSION_MAJOR *100*100 + ZSTD_VERSION_MINOR *100 + ZSTD_VERSION_RELEASE)
-unsigned ZSTD_versionNumber (void);
+ZSTDLIB_API unsigned ZSTD_versionNumber (void);
 
 
 /* *************************************
 *  Simple functions
 ***************************************/
-size_t ZSTD_compress(   void* dst, size_t maxDstSize,
-                  const void* src, size_t srcSize,
-                         int  compressionLevel);
+ZSTDLIB_API size_t ZSTD_compress(   void* dst, size_t maxDstSize,
+                              const void* src, size_t srcSize,
+                                     int  compressionLevel);
 
-size_t ZSTD_decompress( void* dst, size_t maxOriginalSize,
-                  const void* src, size_t compressedSize);
+ZSTDLIB_API size_t ZSTD_decompress( void* dst, size_t maxOriginalSize,
+                              const void* src, size_t compressedSize);
 
 /**
 ZSTD_compress() :
@@ -83,25 +101,25 @@ ZSTD_decompress() :
 /* *************************************
 *  Tool functions
 ***************************************/
-size_t      ZSTD_compressBound(size_t srcSize);   /** maximum compressed size (worst case scenario) */
+ZSTDLIB_API size_t      ZSTD_compressBound(size_t srcSize);   /** maximum compressed size (worst case scenario) */
 
 /* Error Management */
-unsigned    ZSTD_isError(size_t code);         /** tells if a return value is an error code */
-const char* ZSTD_getErrorName(size_t code);    /** provides error code string */
+ZSTDLIB_API unsigned    ZSTD_isError(size_t code);         /** tells if a return value is an error code */
+ZSTDLIB_API const char* ZSTD_getErrorName(size_t code);    /** provides error code string */
 
 
 /* *************************************
 *  Advanced functions
 ***************************************/
 typedef struct ZSTD_CCtx_s ZSTD_CCtx;   /* incomplete type */
-ZSTD_CCtx* ZSTD_createCCtx(void);
-size_t     ZSTD_freeCCtx(ZSTD_CCtx* cctx);
+ZSTDLIB_API ZSTD_CCtx* ZSTD_createCCtx(void);
+ZSTDLIB_API size_t     ZSTD_freeCCtx(ZSTD_CCtx* cctx);
 
 /**
 ZSTD_compressCCtx() :
     Same as ZSTD_compress(), but requires a ZSTD_CCtx working space already allocated
 */
-size_t ZSTD_compressCCtx(ZSTD_CCtx* ctx, void* dst, size_t maxDstSize, const void* src, size_t srcSize, int compressionLevel);
+ZSTDLIB_API size_t ZSTD_compressCCtx(ZSTD_CCtx* ctx, void* dst, size_t maxDstSize, const void* src, size_t srcSize, int compressionLevel);
 
 
 #if defined (__cplusplus)

--- a/lib/zstd.h
+++ b/lib/zstd.h
@@ -48,14 +48,10 @@ extern "C" {
 *****************************************************************/
 /*!
 *  ZSTD_DLL_EXPORT :
-*  Enable exporting of functions when building a DLL
+*  Enable exporting of functions when building a Windows DLL
 */
-#if defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
-#  if _WIN32
-#    define ZSTDLIB_API __declspec(dllexport)
-#  else
-#    define ZSTDLIB_API extern
-#  endif
+#if defined(_WIN32) && defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
+#  define ZSTDLIB_API __declspec(dllexport)
 #else
 #  define ZSTDLIB_API
 #endif

--- a/lib/zstd_buffered.h
+++ b/lib/zstd_buffered.h
@@ -47,6 +47,24 @@ extern "C" {
 #include <stddef.h>   /* size_t */
 
 
+/* ***************************************************************
+*  Tuning parameters
+*****************************************************************/
+/*!
+*  ZSTD_DLL_EXPORT :
+*  Enable exporting of functions when building a DLL
+*/
+#if defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
+#  if _WIN32
+#    define ZSTDLIB_API __declspec(dllexport)
+#  else
+#    define ZSTDLIB_API extern
+#  endif
+#else
+#  define ZSTDLIB_API
+#endif
+
+
 /* *************************************
 *  Streaming functions
 ***************************************/

--- a/lib/zstd_buffered.h
+++ b/lib/zstd_buffered.h
@@ -51,13 +51,13 @@ extern "C" {
 *  Streaming functions
 ***************************************/
 typedef struct ZBUFF_CCtx_s ZBUFF_CCtx;
-ZBUFF_CCtx* ZBUFF_createCCtx(void);
-size_t      ZBUFF_freeCCtx(ZBUFF_CCtx* cctx);
+ZSTDLIB_API ZBUFF_CCtx* ZBUFF_createCCtx(void);
+ZSTDLIB_API size_t      ZBUFF_freeCCtx(ZBUFF_CCtx* cctx);
 
-size_t ZBUFF_compressInit(ZBUFF_CCtx* cctx, int compressionLevel);
-size_t ZBUFF_compressContinue(ZBUFF_CCtx* cctx, void* dst, size_t* maxDstSizePtr, const void* src, size_t* srcSizePtr);
-size_t ZBUFF_compressFlush(ZBUFF_CCtx* cctx, void* dst, size_t* maxDstSizePtr);
-size_t ZBUFF_compressEnd(ZBUFF_CCtx* cctx, void* dst, size_t* maxDstSizePtr);
+ZSTDLIB_API size_t ZBUFF_compressInit(ZBUFF_CCtx* cctx, int compressionLevel);
+ZSTDLIB_API size_t ZBUFF_compressContinue(ZBUFF_CCtx* cctx, void* dst, size_t* maxDstSizePtr, const void* src, size_t* srcSizePtr);
+ZSTDLIB_API size_t ZBUFF_compressFlush(ZBUFF_CCtx* cctx, void* dst, size_t* maxDstSizePtr);
+ZSTDLIB_API size_t ZBUFF_compressEnd(ZBUFF_CCtx* cctx, void* dst, size_t* maxDstSizePtr);
 
 /** ************************************************
 *  Streaming compression
@@ -97,11 +97,11 @@ size_t ZBUFF_compressEnd(ZBUFF_CCtx* cctx, void* dst, size_t* maxDstSizePtr);
 
 
 typedef struct ZBUFF_DCtx_s ZBUFF_DCtx;
-ZBUFF_DCtx* ZBUFF_createDCtx(void);
-size_t      ZBUFF_freeDCtx(ZBUFF_DCtx* dctx);
+ZSTDLIB_API ZBUFF_DCtx* ZBUFF_createDCtx(void);
+ZSTDLIB_API size_t      ZBUFF_freeDCtx(ZBUFF_DCtx* dctx);
 
-size_t ZBUFF_decompressInit(ZBUFF_DCtx* dctx);
-size_t ZBUFF_decompressContinue(ZBUFF_DCtx* dctx, void* dst, size_t* maxDstSizePtr, const void* src, size_t* srcSizePtr);
+ZSTDLIB_API size_t ZBUFF_decompressInit(ZBUFF_DCtx* dctx);
+ZSTDLIB_API size_t ZBUFF_decompressContinue(ZBUFF_DCtx* dctx, void* dst, size_t* maxDstSizePtr, const void* src, size_t* srcSizePtr);
 
 /** ************************************************
 *  Streaming decompression
@@ -129,15 +129,15 @@ size_t ZBUFF_decompressContinue(ZBUFF_DCtx* dctx, void* dst, size_t* maxDstSizeP
 /* *************************************
 *  Tool functions
 ***************************************/
-unsigned ZBUFF_isError(size_t errorCode);
-const char* ZBUFF_getErrorName(size_t errorCode);
+ZSTDLIB_API unsigned ZBUFF_isError(size_t errorCode);
+ZSTDLIB_API const char* ZBUFF_getErrorName(size_t errorCode);
 
 /** The below functions provide recommended buffer sizes for Compression or Decompression operations.
 *   These sizes are not compulsory, they just tend to offer better latency */
-size_t ZBUFF_recommendedCInSize(void);
-size_t ZBUFF_recommendedCOutSize(void);
-size_t ZBUFF_recommendedDInSize(void);
-size_t ZBUFF_recommendedDOutSize(void);
+ZSTDLIB_API size_t ZBUFF_recommendedCInSize(void);
+ZSTDLIB_API size_t ZBUFF_recommendedCOutSize(void);
+ZSTDLIB_API size_t ZBUFF_recommendedDInSize(void);
+ZSTDLIB_API size_t ZBUFF_recommendedDOutSize(void);
 
 
 #if defined (__cplusplus)

--- a/lib/zstd_buffered.h
+++ b/lib/zstd_buffered.h
@@ -52,14 +52,10 @@ extern "C" {
 *****************************************************************/
 /*!
 *  ZSTD_DLL_EXPORT :
-*  Enable exporting of functions when building a DLL
+*  Enable exporting of functions when building a Windows DLL
 */
-#if defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
-#  if _WIN32
-#    define ZSTDLIB_API __declspec(dllexport)
-#  else
-#    define ZSTDLIB_API extern
-#  endif
+#if defined(_WIN32) && defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
+#  define ZSTDLIB_API __declspec(dllexport)
 #else
 #  define ZSTDLIB_API
 #endif

--- a/lib/zstd_buffered_static.h
+++ b/lib/zstd_buffered_static.h
@@ -52,7 +52,7 @@ extern "C" {
 /* *************************************
 *  Advanced Streaming functions
 ***************************************/
-size_t ZBUFF_compressInit_advanced(ZBUFF_CCtx* cctx, ZSTD_parameters params);
+ZSTDLIB_API size_t ZBUFF_compressInit_advanced(ZBUFF_CCtx* cctx, ZSTD_parameters params);
 
 
 #if defined (__cplusplus)

--- a/lib/zstd_static.h
+++ b/lib/zstd_static.h
@@ -180,7 +180,7 @@ ZSTDLIB_API size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t ma
 *  Pre-defined compression levels
 ***************************************/
 #define ZSTD_MAX_CLEVEL 20
-unsigned ZSTD_maxCLevel (void);
+ZSTDLIB_API unsigned ZSTD_maxCLevel (void);
 static const ZSTD_parameters ZSTD_defaultParameters[4][ZSTD_MAX_CLEVEL+1] = {
 {   /* "default" */
     /*    W,  C,  H,  S,  L, strat */

--- a/lib/zstd_static.h
+++ b/lib/zstd_static.h
@@ -85,29 +85,29 @@ typedef struct
 /** ZSTD_getParams
 *   return ZSTD_parameters structure for a selected compression level and srcSize.
 *   srcSizeHint value is optional, select 0 if not known */
-ZSTD_parameters ZSTD_getParams(int compressionLevel, U64 srcSizeHint);
+ZSTDLIB_API ZSTD_parameters ZSTD_getParams(int compressionLevel, U64 srcSizeHint);
 
 /** ZSTD_validateParams
 *   correct params value to remain within authorized range */
-void ZSTD_validateParams(ZSTD_parameters* params);
+ZSTDLIB_API void ZSTD_validateParams(ZSTD_parameters* params);
 
 /** ZSTD_compress_advanced
 *   Same as ZSTD_compressCCtx(), with fine-tune control of each compression parameter */
-size_t ZSTD_compress_advanced (ZSTD_CCtx* ctx,
-                               void* dst, size_t maxDstSize,
-                         const void* src, size_t srcSize,
-                               ZSTD_parameters params);
+ZSTDLIB_API size_t ZSTD_compress_advanced (ZSTD_CCtx* ctx,
+                                           void* dst, size_t maxDstSize,
+                                     const void* src, size_t srcSize,
+                                           ZSTD_parameters params);
 
 
 /* **************************************
 *  Streaming functions (bufferless mode)
 ****************************************/
-size_t ZSTD_compressBegin(ZSTD_CCtx* cctx, void* dst, size_t maxDstSize, int compressionLevel);
-size_t ZSTD_compressBegin_advanced(ZSTD_CCtx* ctx, void* dst, size_t maxDstSize, ZSTD_parameters params);
-size_t ZSTD_compress_insertDictionary(ZSTD_CCtx* ctx, const void* src, size_t srcSize);
+ZSTDLIB_API size_t ZSTD_compressBegin(ZSTD_CCtx* cctx, void* dst, size_t maxDstSize, int compressionLevel);
+ZSTDLIB_API size_t ZSTD_compressBegin_advanced(ZSTD_CCtx* ctx, void* dst, size_t maxDstSize, ZSTD_parameters params);
+ZSTDLIB_API size_t ZSTD_compress_insertDictionary(ZSTD_CCtx* ctx, const void* src, size_t srcSize);
 
-size_t ZSTD_compressContinue(ZSTD_CCtx* cctx, void* dst, size_t maxDstSize, const void* src, size_t srcSize);
-size_t ZSTD_compressEnd(ZSTD_CCtx* cctx, void* dst, size_t maxDstSize);
+ZSTDLIB_API size_t ZSTD_compressContinue(ZSTD_CCtx* cctx, void* dst, size_t maxDstSize, const void* src, size_t srcSize);
+ZSTDLIB_API size_t ZSTD_compressEnd(ZSTD_CCtx* cctx, void* dst, size_t maxDstSize);
 
 /**
   Streaming compression, bufferless mode
@@ -136,15 +136,15 @@ size_t ZSTD_compressEnd(ZSTD_CCtx* cctx, void* dst, size_t maxDstSize);
 
 
 typedef struct ZSTD_DCtx_s ZSTD_DCtx;
-ZSTD_DCtx* ZSTD_createDCtx(void);
-size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
+ZSTDLIB_API ZSTD_DCtx* ZSTD_createDCtx(void);
+ZSTDLIB_API size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);
 
-size_t ZSTD_resetDCtx(ZSTD_DCtx* dctx);
-size_t ZSTD_getFrameParams(ZSTD_parameters* params, const void* src, size_t srcSize);
-void   ZSTD_decompress_insertDictionary(ZSTD_DCtx* ctx, const void* src, size_t srcSize);
+ZSTDLIB_API size_t ZSTD_resetDCtx(ZSTD_DCtx* dctx);
+ZSTDLIB_API size_t ZSTD_getFrameParams(ZSTD_parameters* params, const void* src, size_t srcSize);
+ZSTDLIB_API void   ZSTD_decompress_insertDictionary(ZSTD_DCtx* ctx, const void* src, size_t srcSize);
 
-size_t ZSTD_nextSrcSizeToDecompress(ZSTD_DCtx* dctx);
-size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize, const void* src, size_t srcSize);
+ZSTDLIB_API size_t ZSTD_nextSrcSizeToDecompress(ZSTD_DCtx* dctx);
+ZSTDLIB_API size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize, const void* src, size_t srcSize);
 
 /**
   Streaming decompression, bufferless mode


### PR DESCRIPTION
I'm building a .NET wrapper for Zstandard, and for that I need to build zstd as a windows DLL with a `__declspec(dllexport)` prefix on all the public methods defined in the header files. This allows me to use `LoadLibrary` and `GetProcAddress` at runtime to bind to the native library.

I looked at other projects and how they were adressing this, and used the same pattern as, for example, SQLite which defines a `SQLITE_API` prefix. Other libraries also have a similar LIBFOO_API.

This PR is about adding a `ZSTDLIB_API` macro as a prefix to all public methods in the `zstd_*.h` headers, which is by default not defined. Only when building with `ZSTD_DLL_EXPORT=1` then this macro would be defined as `__declspec(dllexport)` on Win32.

Questions:
- Are the names `ZSTDLIB_API` and `ZSTD_DLL_EXPORT` OK to you?
- How do you document these new compile options? I'm using a custom vcproj for my lib, so I may have missed things in the Makefile
- ~~I'm not exactly sure what to use for non-Win32 platforms. I have currently used `extern` but this may not be the proper keyword? If this needed at all on linux?~~ (not needed on linux)
- I currently have only added a `ZSTDLIB_API` for `zstd*.h`. I'm not directly using fse or huff0, but maybe a similar technique could be used with a `FSE_API` and `HUFF0_LIB` prefix?

note: The CI build initially failed with gcc because it seems that `zstd_buffered.h` does not include `zstd.h`. This did not fail in my VisualStudio project for some reason.

I tried duplicating the definition of ZSTDLIB_API in both files, but I'm not sure how to best solve this, without introducting a common.h that would be included by everyone...