### PR TITLE
Paramgrill math library

### DIFF
--- a/contrib/cmake/programs/CMakeLists.txt
+++ b/contrib/cmake/programs/CMakeLists.txt
@@ -67,8 +67,7 @@ IF (UNIX)
     TARGET_LINK_LIBRARIES(zbufftest libzstd_static)
 
     ADD_EXECUTABLE(paramgrill ${PROGRAMS_DIR}/datagen.c ${PROGRAMS_DIR}/xxhash.c ${PROGRAMS_DIR}/paramgrill.c)
-    TARGET_LINK_LIBRARIES(paramgrill libzstd_static)
-    SET_TARGET_PROPERTIES(paramgrill PROPERTIES LINK_FLAGS "-lm")
+    TARGET_LINK_LIBRARIES(paramgrill libzstd_static m) #m is math library
 
     ADD_EXECUTABLE(datagen ${PROGRAMS_DIR}/datagen.c ${PROGRAMS_DIR}/datagencli.c)
     TARGET_LINK_LIBRARIES(datagen libzstd_static)


### PR DESCRIPTION
Please, test PR cmake build for paramgrill target with gcc 4.8.4. I have only 5.3 and 4.9.3 on my archlinux...