### PR TITLE
Added new ".VC.db" Visual Studio C++ database file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 # Visual solution files
 *.suo
 *.user
+*.VC.db
 
 # Build results
 [Dd]ebug/


### PR DESCRIPTION
Visual Studio 2015 Update 2 adds a new file format for their internal intellisense db engine, with extension ".VC.db", as described in https://www.visualstudio.com/en-us/news/vs2015-update2-vs.aspx#Cdoubleplus

Anyone installing a new version of 2015 Update 2 will get this new format by default, and will get a ~5MB file in the VS solution folder which should probably not be part of the repo.