### PR TITLE
No stdint.h on OpenVMS.

### DIFF
--- a/lib/common/mem.h
+++ b/lib/common/mem.h
@@ -63,7 +63,7 @@ extern "C" {
 /*-**************************************************************
 *  Basic Types
 *****************************************************************/
-#if defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+#if !defined (__VMS) && ( defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
 # include <stdint.h>
   typedef  uint8_t BYTE;
   typedef uint16_t U16;

--- a/programs/datagen.c
+++ b/programs/datagen.c
@@ -34,7 +34,7 @@
 /*-************************************
 *  Basic Types
 **************************************/
-#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
+#if !defined (__VMS) && ( defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */ )
 # include <stdint.h>
   typedef  uint8_t BYTE;
   typedef uint16_t U16;

--- a/programs/xxhash.c
+++ b/programs/xxhash.c
@@ -123,7 +123,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcp
 ***************************************/
 #ifndef MEM_MODULE
 # define MEM_MODULE
-# if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
+# if !defined (__VMS) && ( defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */ )
 #   include <stdint.h>
     typedef uint8_t  BYTE;
     typedef uint16_t U16;


### PR DESCRIPTION
No stdint.h on OpenVMS, it is inttypes.h instead, some projects use HAVE_STDINT_H.