### PR TITLE
Minor changes needed for OpenVMS

### DIFF
--- a/programs/util.h
+++ b/programs/util.h
@@ -95,7 +95,11 @@ extern "C" {
 #  include <unistd.h>
 #  include <sys/resource.h> /* setpriority */
 #  include <time.h>         /* clock_t, nanosleep, clock, CLOCKS_PER_SEC */
-#  define SET_HIGH_PRIORITY setpriority(PRIO_PROCESS, 0, -20)
+#  if defined(PRIO_PROCESS)
+#    define SET_HIGH_PRIORITY setpriority(PRIO_PROCESS, 0, -20)
+#  else
+#    define SET_HIGH_PRIORITY /* disabled */
+#  endif
 #  define UTIL_sleep(s) sleep(s)
 #  if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 199309L)
 #      define UTIL_sleepMilli(milli) { struct timespec t; t.tv_sec=0; t.tv_nsec=milli*1000000ULL; nanosleep(&t, NULL); }

--- a/programs/util.h
+++ b/programs/util.h
@@ -91,7 +91,7 @@ extern "C" {
 #  define SET_HIGH_PRIORITY SetPriorityClass(GetCurrentProcess(), REALTIME_PRIORITY_CLASS)
 #  define UTIL_sleep(s) Sleep(1000*s)
 #  define UTIL_sleepMilli(milli) Sleep(milli)
-#elif (defined(__unix__) || defined(__unix) || defined(__midipix__) || (defined(__APPLE__) && defined(__MACH__))) 
+#elif (defined(__unix__) || defined(__unix) || defined(__VMS) || defined(__midipix__) || (defined(__APPLE__) && defined(__MACH__))) 
 #  include <unistd.h>
 #  include <sys/resource.h> /* setpriority */
 #  include <time.h>         /* clock_t, nanosleep, clock, CLOCKS_PER_SEC */


### PR DESCRIPTION
Define util sleep functions on VMS.
If PRIO_PROCESS is not defined then do not attempt to use it in the definition of SET_HIGH_PRIORITY.