### PR TITLE
Added build commands for various versions of Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ projects/VS2010
 projects/VS2012
 projects/VS2013
 projects/VS2015
+build/bin
 
 # IDEA solution files
 *.idea

--- a/build/build.VS2010.cmd
+++ b/build/build.VS2010.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+rem build 32-bit
+call "%~p0%build.generic.cmd" VS2010 Release "Clean,Build" Win32 v100
+
+rem build 64-bit
+call "%~p0%build.generic.cmd" VS2010 Release "Clean,Build" x64 v100

--- a/build/build.VS2010.cmd
+++ b/build/build.VS2010.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 rem build 32-bit
-call "%~p0%build.generic.cmd" VS2010 Release "Clean,Build" Win32 v100
+call "%~p0%build.generic.cmd" VS2010 Release Rebuild Win32 v100
 
 rem build 64-bit
-call "%~p0%build.generic.cmd" VS2010 Release "Clean,Build" x64 v100
+call "%~p0%build.generic.cmd" VS2010 Release Rebuild x64 v100

--- a/build/build.VS2010.cmd
+++ b/build/build.VS2010.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 rem build 32-bit
-call "%~p0%build.generic.cmd" VS2010 Release Rebuild Win32 v100
+call "%~p0%build.generic.cmd" VS2010 Win32 Release v100
 
 rem build 64-bit
-call "%~p0%build.generic.cmd" VS2010 Release Rebuild x64 v100
+call "%~p0%build.generic.cmd" VS2010 x64 Release v100

--- a/build/build.VS2012.cmd
+++ b/build/build.VS2012.cmd
@@ -1,6 +1,6 @@
 @echo off
 
 rem build 32-bit
-call "%~p0%build.generic.cmd" VS2012 Release "Clean,Build" Win32 v110
+call "%~p0%build.generic.cmd" VS2012 Release Rebuild Win32 v110
 rem build 64-bit
-call "%~p0%build.generic.cmd" VS2012 Release "Clean,Build" x64 v110
+call "%~p0%build.generic.cmd" VS2012 Release Rebuild x64 v110

--- a/build/build.VS2012.cmd
+++ b/build/build.VS2012.cmd
@@ -1,6 +1,6 @@
 @echo off
 
 rem build 32-bit
-call "%~p0%build.generic.cmd" VS2012 Release Rebuild Win32 v110
+call "%~p0%build.generic.cmd" VS2012 Win32 Release v110
 rem build 64-bit
-call "%~p0%build.generic.cmd" VS2012 Release Rebuild x64 v110
+call "%~p0%build.generic.cmd" VS2012 x64 Release v110

--- a/build/build.VS2012.cmd
+++ b/build/build.VS2012.cmd
@@ -1,0 +1,6 @@
+@echo off
+
+rem build 32-bit
+call "%~p0%build.generic.cmd" VS2012 Release "Clean,Build" Win32 v110
+rem build 64-bit
+call "%~p0%build.generic.cmd" VS2012 Release "Clean,Build" x64 v110

--- a/build/build.VS2013.cmd
+++ b/build/build.VS2013.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 rem build 32-bit
-call "%~p0%build.generic.cmd" VS2013 Release Rebuild Win32 v120
+call "%~p0%build.generic.cmd" VS2013 Win32 Release v120
 
 rem build 64-bit
-call "%~p0%build.generic.cmd" VS2013 Release Rebuild x64 v120
+call "%~p0%build.generic.cmd" VS2013 x64 Release v120

--- a/build/build.VS2013.cmd
+++ b/build/build.VS2013.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+rem build 32-bit
+call "%~p0%build.generic.cmd" VS2013 Release "Clean,Build" Win32 v120
+
+rem build 64-bit
+call "%~p0%build.generic.cmd" VS2013 Release "Clean,Build" x64 v120

--- a/build/build.VS2013.cmd
+++ b/build/build.VS2013.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 rem build 32-bit
-call "%~p0%build.generic.cmd" VS2013 Release "Clean,Build" Win32 v120
+call "%~p0%build.generic.cmd" VS2013 Release Rebuild Win32 v120
 
 rem build 64-bit
-call "%~p0%build.generic.cmd" VS2013 Release "Clean,Build" x64 v120
+call "%~p0%build.generic.cmd" VS2013 Release Rebuild x64 v120

--- a/build/build.VS2015.cmd
+++ b/build/build.VS2015.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 rem build 32-bit
-call "%~p0%build.generic.cmd" VS2015 Release Rebuild Win32 v140
+call "%~p0%build.generic.cmd" VS2015 Win32 Release v140
 
 rem build 64-bit
-call "%~p0%build.generic.cmd" VS2015 Release Rebuild x64 v140
+call "%~p0%build.generic.cmd" VS2015 x64 Release v140

--- a/build/build.VS2015.cmd
+++ b/build/build.VS2015.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 rem build 32-bit
-call "%~p0%build.generic.cmd" VS2015 Release "Clean,Build" Win32 v140
+call "%~p0%build.generic.cmd" VS2015 Release Rebuild Win32 v140
 
 rem build 64-bit
-call "%~p0%build.generic.cmd" VS2015 Release "Clean,Build" x64 v140
+call "%~p0%build.generic.cmd" VS2015 Release Rebuild x64 v140

--- a/build/build.VS2015.cmd
+++ b/build/build.VS2015.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+rem build 32-bit
+call "%~p0%build.generic.cmd" VS2015 Release "Clean,Build" Win32 v140
+
+rem build 64-bit
+call "%~p0%build.generic.cmd" VS2015 Release "Clean,Build" x64 v140

--- a/build/build.generic.cmd
+++ b/build/build.generic.cmd
@@ -1,33 +1,46 @@
 @echo off
 
-rem
-rem Parameters
-rem   %1: vs_solution_version: VS solution version: VS2012, VS2013, VS2015
-rem   %2: vs_configuration:    VS configuration:    Debug, Release
-rem   %3: vs_target:           target:              Build or Rebuild
-rem   %4: vs_platform:         platform:            x64 or Win32
-rem   %5: vs_toolset:          toolset:             v100, v110, v120, v140
-rem
+IF "%1%" == "" GOTO display_help
 
-set vs_solution_version=%1
-set vs_configuration=%2
-set vs_target=%3
-set vs_platform=%4
-set vs_toolset=%5
+SET vs_version=%1
 
-set msbuild="%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
-IF %vs_solution_version% == VS2013 SET msbuild="C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe"
-IF %vs_solution_version% == VS2015 SET msbuild="C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
+SET vs_platform=%2
+IF "%vs_platform%" == "" SET vs_platform=x64
+
+SET vs_configuration=%3
+IF "%vs_configuration%" == "" SET vs_configuration=Release
+
+SET vs_toolset=%4
+
+GOTO build
+
+:display_help
+
+echo Syntax: build.generic.cmd vs_version vs_platform vs_configuration vs_toolset
+echo   vs_version:          VS installed version (VS2012, VS2013, VS2015, ...)
+echo   vs_platform:         Platform (x64 or Win32)
+echo   vs_configuration:    VS configuration (Release or Debug)
+echo   vs_toolset:          Platform Toolset (v100, v110, v120, v140)
+
+EXIT /B 1
+
+:build
+
+SET msbuild="%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+IF %vs_version% == VS2013 SET msbuild="C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe"
+IF %vs_version% == VS2015 SET msbuild="C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
 rem TODO: Visual Studio "15" (vNext) will use MSBuild 15.0 ?
 
-set project="%~p0\..\projects\VS2010\zstd.sln"
+SET project="%~p0\..\projects\VS2010\zstd.sln"
 
-set output=%~p0%bin
-set output="%output%/%vs_solution_version%/%vs_platform%/"
+SET msbuildparams=/verbosity:minimal /nologo /t:Clean,Build /p:Platform=%vs_platform% /p:Configuration=%vs_configuration%
+IF NOT "%vs_toolset%" == "" SET msbuildparams=%msbuildparams% /p:PlatformToolset=%vs_toolset%
 
-set msbuildparams=/verbosity:minimal /p:Platform="%vs_platform%" /p:Configuration="%vs_configuration%" /p:PlatformToolset="%vs_toolset%" /t:Clean,Build /nologo /p:OutDir=%output%
+SET output=%~p0%bin
+SET output="%output%/%vs_configuration%/%vs_platform%/"
+SET msbuildparams=%msbuildparams% /p:OutDir=%output%
 
-echo ### Building %vs_solution_version% project for %vs_configuration% %vs_platform% (%vs_toolset%)...
+echo ### Building %vs_version% project for %vs_configuration% %vs_platform% (%vs_toolset%)...
 echo ### Build Params: %msbuildparams%
 
 %msbuild% %project% %msbuildparams%

--- a/build/build.generic.cmd
+++ b/build/build.generic.cmd
@@ -1,0 +1,38 @@
+@echo off
+
+rem
+rem Parameters
+rem   %1: vs_solution_version: VS solution version: VS2012, VS2013, VS2015
+rem   %2: vs_configuration:    VS configuration:    Debug, Release
+rem   %3: vs_target:           target:              Build or Rebuild
+rem   %4: vs_platform:         platform:            x64 or Win32
+rem   %5: vs_toolset:          toolset:             v100, v110, v120, v140
+rem
+
+set vs_solution_version=%1
+set vs_configuration=%2
+set vs_target=%3
+set vs_platform=%4
+set vs_toolset=%5
+
+set msbuild="%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+IF %vs_solution_version% == VS2013 SET msbuild="C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe"
+IF %vs_solution_version% == VS2015 SET msbuild="C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
+rem TODO: Visual Studio "15" (vNext) will use MSBuild 15.0 ?
+
+set project="%~p0\..\projects\VS2010\zstd.sln"
+
+set output=%~p0%bin
+set output="%output%/%vs_solution_version%/%vs_platform%/"
+
+set msbuildparams=/verbosity:minimal /p:Platform="%vs_platform%" /p:Configuration="%vs_configuration%" /p:PlatformToolset="%vs_toolset%" /t:Clean,Build /nologo /p:OutDir=%output%
+
+echo ### Building %vs_solution_version% project for %vs_configuration% %vs_platform% (%vs_toolset%)...
+echo ### Build Params: %msbuildparams%
+
+%msbuild% %project% %msbuildparams%
+IF ERRORLEVEL 1 EXIT /B 1
+echo # Success
+echo # OutDir: %output%
+echo #
+


### PR DESCRIPTION
This PR adds a set of build commands for Windows, intended for people who want to quickly build `zstd.exe` or `zstdlib_*.dll` without needing to open Visual Studio and fight with the project conversion process (see Issue #201 for the context), and is inspired by the build scripts used in [GitExtensions](https://github.com/gitextensions/gitextensions/blob/aefed53bb6879658e3eb22322dcb9cae93a05547/Build/build.generic.cmd)

- `build.generic.cmd` is the main build script that runs msbuild on the Visual Studio project, for a specific configuration (ex: Release, x64, v120).
- `build.VSxxx.cmd` are helper scripts that call `build.generic.cmd` with a set of default settings for this particular version of Visual Studio.

For example, somone with Visual Studio 2013 installed, would run `build.VS2013.cmd` and get a version of `zstd.exe` compiled with msbuild v12.0 and targeting MSCVR120.dll. Likewise, `build.VS2015.cmd` would build the project using msbuild v14.0 / MSCVR140.dll.

People checking out the repository, and just wanting to build `zstd.exe` or `zstdlib_xxx.dll` to play with it, will only need to run the corresponding build.VSxxx.cmd (matching the version they have installed), and be done.

People who need fine grained settings, or wanting to integrate this with a build server, would probably `build.generic.cmd` with the exact set of arguments they want...or more probably call msbuild themselves...

__TO BE DECIDED / NOT TESTED YET__

- The result of the build is stored in `build/bin/{VS_VERSION}/{ARCH}/` so for example `build/bin/VS2013/x64/`, instead of under each of the `projects/VS2010/{PROJECT}/x64/Release` folders. This makes it simpler to access imho because you are already in the build folder.

- I call msbuild with `Clean,Build` target, which has the side effect of clearing everything under `build/bin` for some reason. This wipes previous builds (especially if you build x86 then x64, then the x86 build gets wiped, which is unfortunate). Don't know how to prevent that.

- Currently, `build.VSxxx.cmd` build both Win32 and x64 build at the same time. If this is not desirable, I would need to duplicate all scripts, and have `build.VS2013.Win32.cmd` and `build.VS2013.x64.cmd`. I don't know what is best.

- There is no way to choose between statically linked vs dynamically linked. We would need to add another argument to `build.generic.cmd` for that.

- I was not able to test the VS2010 and VS2012 build scripts because I don't have them installed anywhere, so I don't know if these scripts work.

- No integration with CMake... is this needed? If CMake would create version of the projects specific to VS20xx, then maybe the `build.VS20xx.cmd` count use the path to that project, instead of defaulting to the VS2010 project?