### PR TITLE
Fix hardcoded path in msbuild scripts

### DIFF
--- a/build/build.generic.cmd
+++ b/build/build.generic.cmd
@@ -2,48 +2,50 @@
 
 IF "%1%" == "" GOTO display_help
 
-SET vs_version=%1
+SETLOCAL
 
-SET vs_platform=%2
-IF "%vs_platform%" == "" SET vs_platform=x64
+SET msbuild_version=%1
 
-SET vs_configuration=%3
-IF "%vs_configuration%" == "" SET vs_configuration=Release
+SET msbuild_platform=%2
+IF "%msbuild_platform%" == "" SET msbuild_platform=x64
 
-SET vs_toolset=%4
+SET msbuild_configuration=%3
+IF "%msbuild_configuration%" == "" SET msbuild_configuration=Release
+
+SET msbuild_toolset=%4
 
 GOTO build
 
 :display_help
 
-echo Syntax: build.generic.cmd vs_version vs_platform vs_configuration vs_toolset
-echo   vs_version:          VS installed version (VS2012, VS2013, VS2015, ...)
-echo   vs_platform:         Platform (x64 or Win32)
-echo   vs_configuration:    VS configuration (Release or Debug)
-echo   vs_toolset:          Platform Toolset (v100, v110, v120, v140)
+echo Syntax: build.generic.cmd msbuild_version msbuild_platform msbuild_configuration msbuild_toolset
+echo   msbuild_version:          VS installed version (VS2012, VS2013, VS2015, ...)
+echo   msbuild_platform:         Platform (x64 or Win32)
+echo   msbuild_configuration:    VS configuration (Release or Debug)
+echo   msbuild_toolset:          Platform Toolset (v100, v110, v120, v140)
 
 EXIT /B 1
 
 :build
 
 SET msbuild="%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
-IF %vs_version% == VS2013 SET msbuild="C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe"
-IF %vs_version% == VS2015 SET msbuild="C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
+IF %msbuild_version% == VS2013 SET msbuild="%programfiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
+IF %msbuild_version% == VS2015 SET msbuild="%programfiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
 rem TODO: Visual Studio "15" (vNext) will use MSBuild 15.0 ?
 
 SET project="%~p0\..\projects\VS2010\zstd.sln"
 
-SET msbuildparams=/verbosity:minimal /nologo /t:Clean,Build /p:Platform=%vs_platform% /p:Configuration=%vs_configuration%
-IF NOT "%vs_toolset%" == "" SET msbuildparams=%msbuildparams% /p:PlatformToolset=%vs_toolset%
+SET msbuild_params=/verbosity:minimal /nologo /t:Clean,Build /p:Platform=%msbuild_platform% /p:Configuration=%msbuild_configuration%
+IF NOT "%msbuild_toolset%" == "" SET msbuild_params=%msbuild_params% /p:PlatformToolset=%msbuild_toolset%
 
 SET output=%~p0%bin
-SET output="%output%/%vs_configuration%/%vs_platform%/"
-SET msbuildparams=%msbuildparams% /p:OutDir=%output%
+SET output="%output%/%msbuild_configuration%/%msbuild_platform%/"
+SET msbuild_params=%msbuild_params% /p:OutDir=%output%
 
-echo ### Building %vs_version% project for %vs_configuration% %vs_platform% (%vs_toolset%)...
-echo ### Build Params: %msbuildparams%
+echo ### Building %msbuild_version% project for %msbuild_configuration% %msbuild_platform% (%msbuild_toolset%)...
+echo ### Build Params: %msbuild_params%
 
-%msbuild% %project% %msbuildparams%
+%msbuild% %project% %msbuild_params%
 IF ERRORLEVEL 1 EXIT /B 1
 echo # Success
 echo # OutDir: %output%


### PR DESCRIPTION
This address feedback from #201 by fixing the hardcoded path to `Program Files (X86)`, as well as fixing a leak of the variables defined in the script by adding `SETLOCAL`

- Whether running on 32-bit, 64-bit or WoW64, `%programfiles(x86)%` returns `C:\Program Files (x86)` by default.
- Without `SETLOCAL`, the script would leak all variables defined via `SET` in the CMD session, even after the scripts exists.