### PR TITLE
Fix Max Compression Level in zstd.1

### DIFF
--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -43,7 +43,7 @@ It also features a very fast decoder, with speed > 500 MB/s per core.
 .SH OPTIONS
 .TP
 .B \-#
- # compression level [1-21] (default:1)
+ # compression level [1-22] (default:1)
 .TP
 .BR \-d ", " --decompress
  decompression


### PR DESCRIPTION
This is also wrong in master.

The file seems outdated, the "--ultra" parameter is also not listed.
Is this man-page still used?