### PR TITLE
fixing a segfault

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -325,7 +325,7 @@ static size_t ZSTD_resetCCtx_advanced (ZSTD_CCtx* zc,
     zc->seqStore.mlCodeStart = zc->seqStore.llCodeStart + maxNbSeq;
     zc->seqStore.offCodeStart = zc->seqStore.mlCodeStart + maxNbSeq;
     zc->seqStore.litStart = zc->seqStore.offCodeStart + maxNbSeq;
-
+    ZSTD_resetSeqStore(&zc->seqStore);
     zc->stage = 1;
     zc->dictID = 0;
     zc->loadedDictEnd = 0;


### PR DESCRIPTION
The commit fixes a crash in the following code path:

The crash was caused by an out-of-memory access here:
```c
void ZSTD_seqToCodes(const seqStore_t* seqStorePtr, size_t const nbSeq)
{
...
        size_t u;
        for (u=0; u<nbSeq; u++) {
            U32 const  ll = llTable[u];
            llCodeTable[u] = (ll>63) ? (BYTE)ZSTD_highbit(ll) + LL_deltaCode : LL_Code[ll];
        }
```

The gdb showed a really huge nbSeq originating from here:
```c
    const U32*  const offsetTable = seqStorePtr->offsetStart;
    const U32*  const offsetTableEnd = seqStorePtr->offset;
...
    size_t const nbSeq = offsetTableEnd - offsetTable;
```

The `offsetTableEnd` was zero. The AddressSanitizer showed that the buffer was malloc'ed in `ZSTD_resetCCtx_advanced`. The initialization code seemed unfinished and after a brief examination of the surroundings I found `ZSTD_resetSeqStore` function which I believe does the right thing (and fixes the issue for me).