### PR TITLE
Redundant entry for options in the man page.

### DIFF
--- a/programs/zstd.1
+++ b/programs/zstd.1
@@ -39,7 +39,6 @@ It also features a very fast decoder, with speed > 500 MB/s per core.
      Use \fB-q\fR to turn them off
 
 
-\fBzstd\fR supports the following options :
 
 .SH OPTIONS
 .TP


### PR DESCRIPTION
".SH OPTIONS" is enough.

Closes #234 