### PR TITLE
Add more descriptive message to -v option in zstd CLI

### DIFF
--- a/programs/zstdcli.c
+++ b/programs/zstdcli.c
@@ -92,6 +92,8 @@
 #define MB *(1 <<20)
 #define GB *(1U<<30)
 
+#define DEFAULT_DISPLAY_LEVEL 2
+
 static const char*    g_defaultDictName = "dictionary";
 static const unsigned g_defaultMaxDictSize = 110 KB;
 static const int      g_defaultDictCLevel = 5;
@@ -104,7 +106,7 @@ static const unsigned g_defaultSelectivityLevel = 9;
 #define DISPLAY(...)           fprintf(displayOut, __VA_ARGS__)
 #define DISPLAYLEVEL(l, ...)   if (displayLevel>=l) { DISPLAY(__VA_ARGS__); }
 static FILE* displayOut;
-static unsigned displayLevel = 2;   /* 0 : no display,  1: errors,  2 : + result + interaction + warnings,  3 : + progression,  4 : + information */
+static unsigned displayLevel = DEFAULT_DISPLAY_LEVEL;   /* 0 : no display,  1: errors,  2 : + result + interaction + warnings,  3 : + progression,  4 : + information */
 
 
 /*-************************************
@@ -140,7 +142,7 @@ static int usage_advanced(const char* programName)
     DISPLAY( "\n");
     DISPLAY( "Advanced arguments :\n");
     DISPLAY( " -V     : display Version number and exit\n");
-    DISPLAY( " -v     : verbose mode\n");
+    DISPLAY( " -v     : verbose mode; specify multiple times to increase log level (default:%d)\n", DEFAULT_DISPLAY_LEVEL);
     DISPLAY( " -q     : suppress warnings; specify twice to suppress errors too\n");
     DISPLAY( " -c     : force write to standard output, even if it is the console\n");
 #ifdef UTIL_HAS_CREATEFILELIST


### PR DESCRIPTION
Test Plan:

```
davidlam-mbp:zstd davidlam$ ./zstd --help | grep verbose

 -v     : verbose mode; specify multiple times to increase log level (default:2)
davidlam-mbp:zstd davidlam$ ./zstd ./README.md -o /dev/null

./README.md          : 45.69%   (  5529 =>   2526 bytes, /dev/null)
davidlam-mbp:zstd davidlam$ ./zstd -v ./README.md -o /dev/null

*** zstd command line interface 64-bits v0.8.1, by Yann Collet ***
./README.md          : 45.69%   (  5529 =>   2526 bytes, /dev/null)
davidlam-mbp:zstd davidlam$ ./zstd -v -v ./README.md -o /dev/null

*** zstd command line interface 64-bits v0.8.1, by Yann Collet ***
./README.md          : 45.69%   (  5529 =>   2526 bytes, /dev/null)
Completed in 0.00 sec
davidlam-mbp:zstd davidlam$ ./zstd -v -v -v ./README.md -o /dev/null

*** zstd command line interface 64-bits v0.8.1, by Yann Collet ***
./README.md          : 45.69%   (  5529 =>   2526 bytes, /dev/null)
Completed in 0.00 sec
davidlam-mbp:zstd davidlam$ ./zstd -vv ./README.md -o /dev/null

*** zstd command line interface 64-bits v0.8.1, by Yann Collet ***
./README.md          : 45.69%   (  5529 =>   2526 bytes, /dev/null)
Completed in 0.00 sec
davidlam-mbp:zstd davidlam$ ./zstd -vvv ./README.md -o /dev/null

*** zstd command line interface 64-bits v0.8.1, by Yann Collet ***
./README.md          : 45.69%   (  5529 =>   2526 bytes, /dev/null)
Completed in 0.00 sec
```