### PR TITLE
Add a link to C# binding

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,7 @@ here is a list of known bindings and their authors :
 | Language     | Author              | URL                                   |
 | ------------ | ------------------- | ------------------------------------- |
 | __Java__     | Luben Karavelov     | https://github.com/luben/zstd-jni     |
+| __C#__       | SKB Kontur          | https://github.com/skbkontur/ZstdNet  |
 | __Rust__     | Alexandre Bury      | https://crates.io/crates/zstd         |
 | __Ada__      | John Marino         | https://github.com/jrmarino/zstd-ada  |
 | __Python__   | Sergey Dryabzhinsky | https://pypi.python.org/pypi/zstd     |


### PR DESCRIPTION
I suggest adding a link to C# binding. The link is inserted so as to maintain binding order mentioned [here](https://github.com/Cyan4973/zstd/pull/276#issuecomment-236909368).